### PR TITLE
Resolve deprecation warnings.

### DIFF
--- a/Example/EzPopup/NumberPickerViewController.swift
+++ b/Example/EzPopup/NumberPickerViewController.swift
@@ -8,7 +8,7 @@
 
 import UIKit
 
-protocol NumberPickerViewControllerDelegate: class {
+protocol NumberPickerViewControllerDelegate: AnyObject {
     func numberPickerViewController(sender: NumberPickerViewController, didSelectNumber number: Int)
 }
 

--- a/EzPopup/Classes/PopupViewController.swift
+++ b/EzPopup/Classes/PopupViewController.swift
@@ -7,7 +7,7 @@
 
 import UIKit
 
-public protocol PopupViewControllerDelegate: class {
+public protocol PopupViewControllerDelegate: AnyObject {
     
     /// It is called when pop up is dismissed by tap outside
     func popupViewControllerDidDismissByTapGesture(_ sender: PopupViewController)


### PR DESCRIPTION
Building with this library generates a warning due to an out-of-date declaration.

This PR resolves that warning so that project using EzPopup may build without warnings. The corresponding change is also made in the Example project.